### PR TITLE
make it run on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
+SET(CMAKE_CXX_STANDARD 17)
 
 project(Battler)
 
@@ -17,30 +18,32 @@ add_executable(Battler
 	vm/game.h
 )
 
-add_library(paper
-	SHARED
-	Expression.cpp
-	vm/Compiler.cpp
-	Parser.cpp
-	InterpreterErrors.cpp
-	vm/game.cpp
-	paper.cpp
-	Battler.h
-	expression.h
-	interpreter_errors.h
-	Parser.h
-	Compiler.h
-	vm/game.h
-	paper.h
-)
+if (WIN32)
+	add_library(paper
+		SHARED
+		Expression.cpp
+		vm/Compiler.cpp
+		Parser.cpp
+		InterpreterErrors.cpp
+		vm/game.cpp
+		paper.cpp
+		Battler.h
+		expression.h
+		interpreter_errors.h
+		Parser.h
+		Compiler.h
+		vm/game.h
+		paper.h
+	)
 
-target_compile_definitions(paper PRIVATE PAPER_EXPORTS=1)
+	target_compile_definitions(paper PRIVATE PAPER_EXPORTS=1)
 
-install(
-	TARGETS Battler paper
-)
-install(
-	FILES 
-	paper.h
-	DESTINATION include
-)
+	install(
+		TARGETS Battler paper
+	)
+	install(
+		FILES 
+		paper.h
+		DESTINATION include
+	)
+endif()

--- a/Expression.cpp
+++ b/Expression.cpp
@@ -394,7 +394,7 @@ namespace Battler {
     }
 
     Expression GetPlayersExpression(std::vector<Token>::iterator& current, const std::vector<Token>::iterator end) {
-        Expression expr(ExpressionType::PLAYERS_DECLARATION, { *current });
+        Expression expr(ExpressionType::PLAYERS_DECLARATION, {*current});
 
         ensureNoEOF(++current, end);
 

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -17,7 +17,7 @@ namespace Battler {
 		std::string::iterator end
 	) {
 
-		assert(begin != end, "begin does not equal end");
+		assert(begin != end);
 
 		Token t;
 

--- a/Parser.h
+++ b/Parser.h
@@ -7,7 +7,7 @@
 #include <cassert>
 
 namespace Battler {
-	enum class TokenType {
+	enum TokenType {
 		assignment,
 		equality,
 		plus,

--- a/expression.h
+++ b/expression.h
@@ -73,10 +73,9 @@ namespace Battler {
         std::vector<Token> tokens;
         std::vector<Expression> children;
         Expression() {}
-        Expression(ExpressionType type, std::vector<Token> tokens) : type{ type }, tokens{ tokens } {}
+        Expression(ExpressionType type_in, std::vector<Token> tokens_in) : type( type_in ), tokens(tokens_in) {}
     };
 
-    Expression GetExpression(std::vector<Token>::iterator& current, const std::vector<Token>::iterator end);
     ExpressionType GetExpressionTypeFromOperatorTokenType(TokenType type);
     std::vector<Token> GetIdentifierTokens(std::vector<Token>::iterator& current, const std::vector<Token>::iterator end);
     std::vector<Expression> GetBlock(std::vector<Token>::iterator& current, const std::vector<Token>::iterator end);

--- a/interpreter_errors.h
+++ b/interpreter_errors.h
@@ -8,19 +8,19 @@ namespace Battler {
     public:
         Token t;
         std::string reason;
-        UnexpectedTokenException(Token t, std::string reason) : t{ t }, reason{ reason } {}
+        UnexpectedTokenException(Token t, std::string reason) : t( t ), reason(reason) {}
     };
 
     class NoNameException {
     public:
         std::string name;
-        NoNameException(std::string name) : name{ name } {}
+        NoNameException(std::string name) : name( name ) {}
     };
 
     class NameRedeclaredException {
     public:
         std::string name;
-        NameRedeclaredException(std::string name) : name{ name } {}
+        NameRedeclaredException(std::string name) : name(name) {}
     };
 
     void ensureNoEOF(const std::vector<Token>::iterator t, const std::vector<Token>::iterator end);

--- a/vm/Compiler.cpp
+++ b/vm/Compiler.cpp
@@ -37,7 +37,8 @@ void Program::Compile(vector<string> lines)
 		}
 	}
 
-	m_rootExpression = GetExpression(m_tokens.begin(), m_tokens.end());
+    auto tokens_begin = m_tokens.begin();
+	m_rootExpression = GetExpression(tokens_begin, m_tokens.end());
 	compile_expression(m_rootExpression);
 }
 


### PR DESCRIPTION
There are a few places where the syntax was wrong but MSVC++ wasn't complaining, but clang was. Also we don't bother building a shared library on macOS.

Set the C++ Standard to 17